### PR TITLE
Add docs/ to .gitignore for local documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lerna-debug.log*
 
 # misc
 .DS_Store
+
+# Documentation (local only)
+docs/


### PR DESCRIPTION
## Summary
ローカルでの開発ドキュメントやメモを管理するために、`docs/` ディレクトリを.gitignoreに追加します。

## Changes
- `.gitignore` に `docs/` を追加
- 開発者が個人的なメモやドキュメントをローカルで安全に管理可能

## Rationale
- 個人的な開発ログや学習メモをプロジェクトリポジトリに混入させない
- チーム全体で同じルールを適用
- プライベートなドキュメント管理の明確化

## Test plan
- [ ] `docs/` ディレクトリを作成してもgitに追跡されないことを確認
- [ ] 既存の.gitignoreルールが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)