### PR TITLE
refactor: ハンバーガーメニューのCSS刷新

### DIFF
--- a/app/islands/Header.tsx
+++ b/app/islands/Header.tsx
@@ -12,6 +12,7 @@ const headerClass = css`
   max-width: var(--content-max-width);
   z-index: 50;
   box-shadow: var(--header-shadow);
+  anchor-name: --header;
   position: fixed;
   top: var(--spacing-base);
   left: 0;
@@ -95,7 +96,7 @@ const navLinkListClass = css`
     & li:not(:last-child) {
       display: none;
     }
-    
+
     & li:last-child {
       display: flex;
       align-items: center;
@@ -141,45 +142,81 @@ const hamburgerButtonClass = css`
   border: none;
   cursor: pointer;
   margin: 0 auto;
-  display: flex;
-  align-items: center;
+  display: grid;
+  place-items: center;
   height: 100%;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+
+  & > span {
+    grid-area: 1 / 1;
+  }
 
   @media (hover: hover) {
     &:hover {
       transition: transform 0.2s ease-in-out, fill 0.2s ease-in-out;
       transform: scale(1.1);
 
-      & > svg > path {
+      & > span > svg > path {
         fill: var(--color-primary);
       }
     }
   }
 `
 
+const hamburgerIconClass = css`
+  display: flex;
+  opacity: 1;
+  rotate: 0deg;
+  transition: opacity 0.3s ease-out, rotate 0.3s ease-out;
+
+  header:has(:popover-open) & {
+    opacity: 0;
+    rotate: 180deg;
+  }
+`
+
+const closeIconClass = css`
+  display: flex;
+  opacity: 0;
+  rotate: -180deg;
+  transition: opacity 0.3s ease-out, rotate 0.3s ease-out;
+
+  header:has(:popover-open) & {
+    opacity: 1;
+    rotate: 0deg;
+  }
+`
+
 const hamburgerMenuClass = css`
-  border: var(--border-width-thick) solid var(--color-hamburger-border);
-  border-radius: var(--round-md);
-  width: 200px;
-  margin: 0 auto;
-  transition:
-    translate .2s ease-out,
-    display .2s ease-out allow-discrete,
-    overlay .2s ease-out allow-discrete;
-  translate: 48px -40px;
-  box-shadow: var(--shadow-md);
-  top: 0;
-  left: auto;
   background-color: var(--color-header-background);
-  color: currentColor;
+  color: var(--color-header-foreground);
+  border: none;
+  box-shadow: var(--header-shadow);
+  border-radius: 0 0 var(--round-md) var(--round-md);
+  padding: 0;
+  margin: 0;
+  inset: unset;
+  position-anchor: --header;
+  position-area: bottom end;
+  margin-top: calc(-1 * var(--spacing-base));
+  width: 150px;
+
+  clip-path: inset(0 0 100% 0);
+  transition:
+    clip-path 0.25s ease-in,
+    display 0.25s ease-in allow-discrete,
+    overlay 0.25s ease-in allow-discrete;
 
   &:popover-open {
-    translate: 48px -40px;
-    
+    clip-path: inset(0 0 0 0);
+    transition:
+      clip-path 0.25s ease-out,
+      display 0.25s ease-out allow-discrete,
+      overlay 0.25s ease-out allow-discrete;
+
     @starting-style {
-      translate: 200px -40px;
+      clip-path: inset(0 0 100% 0);
     }
   }
 
@@ -192,7 +229,7 @@ const hamburgerMenuClass = css`
     font-size: clamp(var(--text-md), 2.5vw, var(--text-lg));
     font-weight: var(--font-semibold);
     margin: auto 0;
-   
+
     & a {
       position: relative;
 
@@ -206,12 +243,12 @@ const hamburgerMenuClass = css`
         background-color: var(--color-primary);
         transition: width 0.3s ease;
       }
-      
+
       &:hover {
         opacity: 0.8;
         transition: opacity 0.2s ease-in-out;
       }
-      
+
       &:hover::after {
         width: 100%;
       }
@@ -251,6 +288,11 @@ export const Header = ({ initialTheme, currentPath }: { initialTheme: Theme, cur
       }
 
       setLastScrollY(currentY);
+
+      const menu = document.getElementById('menu2');
+      if (menu?.matches(':popover-open')) {
+        menu.hidePopover();
+      }
     }
 
     window.addEventListener("scroll", handleScroll);
@@ -280,17 +322,15 @@ export const Header = ({ initialTheme, currentPath }: { initialTheme: Theme, cur
             <ThemeToggle initialTheme={initialTheme} />
           </li>
           <li>
-            <button popovertarget="menu" class={hamburgerButtonClass} aria-label="Open menu">
-              <HamburgerIcon />
+            <button popovertarget="menu2" class={hamburgerButtonClass} aria-label="Open menu">
+              <span class={hamburgerIconClass}><HamburgerIcon /></span>
+              <span class={closeIconClass}><CloseIcon /></span>
             </button>
           </li>
         </ul>
       </nav>
 
-      <aside popover id="menu" class={hamburgerMenuClass}>
-        <button popovertarget="menu" popovertargetaction="hide" class={closeButtonClass}>
-          <CloseIcon />
-        </button>
+      <aside popover id="menu2" class={hamburgerMenuClass}>
         <ul>
           <li>
             <a href="/posts" data-current={currentPath.startsWith('/posts') ? 'true' : 'false'}>Posts</a></li>

--- a/app/islands/Header.tsx
+++ b/app/islands/Header.tsx
@@ -11,7 +11,7 @@ const headerClass = css`
   color: var(--color-header-foreground);
   max-width: var(--content-max-width);
   z-index: 50;
-  box-shadow: var(--header-shadow);
+  border: var(--header-border);
   anchor-name: --header;
   position: fixed;
   top: var(--spacing-base);
@@ -19,13 +19,22 @@ const headerClass = css`
   right: 0;
   margin-inline: auto;
   border-radius: var(--round-lg);
-  padding: var(--spacing-base) var(--spacing-xl);
+  padding: var(--spacing-base) var(--spacing-md);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  transition: 
+  transition:
     transform 0.3s ease-in-out,
-    opacity 0.3s ease-in-out;
+    opacity 0.3s ease-in-out,
+    border-bottom-right-radius 0.65s ease-in-out;
+
+  &:has(:popover-open) {
+    border-bottom-right-radius: 0;
+    transition:
+      transform 0.3s ease-in-out,
+      opacity 0.3s ease-in-out,
+      border-bottom-right-radius 0s;
+  }
 
   @media (max-width: 1100px) {
     margin-inline: var(--spacing-md);
@@ -191,29 +200,28 @@ const closeIconClass = css`
 const hamburgerMenuClass = css`
   background-color: var(--color-header-background);
   color: var(--color-header-foreground);
-  border: none;
-  box-shadow: var(--header-shadow);
+  border: var(--header-border);
+  border-top: none;
   border-radius: 0 0 var(--round-md) var(--round-md);
   padding: 0;
   margin: 0;
   inset: unset;
   position-anchor: --header;
-  position-area: bottom end;
-  margin-top: calc(-1 * var(--spacing-base));
-  width: 150px;
+  top: anchor(--header bottom);
+  left: calc(100% - 156px);
+  margin-top: calc(-1 * var(--border-width-thick));
+  width: 140px;
 
+  opacity: 1;
   clip-path: inset(0 0 100% 0);
-  transition:
-    clip-path 0.25s ease-in,
-    display 0.25s ease-in allow-discrete,
-    overlay 0.25s ease-in allow-discrete;
+
+  transition-property: clip-path, display, overlay;
+  transition-duration: 0.35s;
+  transition-timing-function: ease-in-out;
+  transition-behavior: normal, allow-discrete, allow-discrete;
 
   &:popover-open {
     clip-path: inset(0 0 0 0);
-    transition:
-      clip-path 0.25s ease-out,
-      display 0.25s ease-out allow-discrete,
-      overlay 0.25s ease-out allow-discrete;
 
     @starting-style {
       clip-path: inset(0 0 100% 0);
@@ -256,23 +264,6 @@ const hamburgerMenuClass = css`
   }
 `
 
-const closeButtonClass = css`
-  position: absolute;
-  top: var(--spacing-md);
-  right: var(--spacing-md);
-  background: none;
-  border: none;
-  filter: grayscale(100);
-  cursor: pointer;
-  user-select: none;
-  -webkit-tap-highlight-color: transparent;
-
-  &:hover {
-    opacity: 0.7;
-    transition: opacity 0.2s ease-in-out;
-  }
-`
-
 export const Header = ({ initialTheme, currentPath }: { initialTheme: Theme, currentPath: string }) => {
   const [visible, setVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
@@ -289,9 +280,11 @@ export const Header = ({ initialTheme, currentPath }: { initialTheme: Theme, cur
 
       setLastScrollY(currentY);
 
-      const menu = document.getElementById('menu2');
-      if (menu?.matches(':popover-open')) {
-        menu.hidePopover();
+      if (currentY >= 300 && currentY > lastScrollY) {
+        const menu = document.getElementById('menu2');
+        if (menu?.matches(':popover-open')) {
+          menu.hidePopover();
+        }
       }
     }
 
@@ -322,7 +315,7 @@ export const Header = ({ initialTheme, currentPath }: { initialTheme: Theme, cur
             <ThemeToggle initialTheme={initialTheme} />
           </li>
           <li>
-            <button popovertarget="menu2" class={hamburgerButtonClass} aria-label="Open menu">
+            <button popovertarget="menu" class={hamburgerButtonClass} aria-label="Open menu">
               <span class={hamburgerIconClass}><HamburgerIcon /></span>
               <span class={closeIconClass}><CloseIcon /></span>
             </button>
@@ -330,7 +323,7 @@ export const Header = ({ initialTheme, currentPath }: { initialTheme: Theme, cur
         </ul>
       </nav>
 
-      <aside popover id="menu2" class={hamburgerMenuClass}>
+      <aside popover="auto" id="menu" class={hamburgerMenuClass}>
         <ul>
           <li>
             <a href="/posts" data-current={currentPath.startsWith('/posts') ? 'true' : 'false'}>Posts</a></li>


### PR DESCRIPTION
## Summary
- ハンバーガーメニューをCSS Anchor Positioning + clip-pathアニメーションに刷新
- Popover APIの閉じアニメーション（exit animation）が効かない問題を修正
- ヘッダーのbox-shadowをborderに統一し、メニューとの接続部を改善
- HamburgerIcon ↔ CloseIconのCSS-onlyトグルアニメーション（`:has(:popover-open)`）

## 主な変更点
- **CSS Anchor Positioning**: `position-anchor` / `anchor()` でメニューをヘッダー直下に配置
- **clip-path shutter animation**: `clip-path: inset()` でシャッター風の開閉アニメーション
- **exit animation修正**: グローバルCSS（base.css）の`[popover] { opacity: 0 }`による干渉を`opacity: 1`で上書き
- **hono/css対応**: `cubic-bezier()`のカンマ問題を回避するためtransitionをロングハンドに分解
- **border-radius transition**: popover開閉時にヘッダー右下の角丸を連動（開く時は即時、閉じる時は0.65s）
- **popover属性修正**: `popover`(boolean) → `popover="auto"`（Hono JSXの互換性対応）

## Test plan
- [ ] モバイルサイズでハンバーガーメニューの開閉アニメーションを確認
- [ ] 閉じる時のシャッターアニメーション（clip-path）が正しく動作すること
- [ ] ヘッダーとメニューのボーダー接続部に隙間がないこと
- [ ] スクロールダウン時にメニューが自動で閉じること
- [ ] アイコンの回転トグルアニメーションが動作すること
- [ ] ライト/ダークモード両方で表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)