### PR TITLE
refactor: TOC型整理・モバイル目次追加・記事詳細スタイル調整

### DIFF
--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -1,8 +1,8 @@
 import { css } from "hono/css";
-import type { Heading } from "../types/post";
+import type { groupedHeading } from "../types/post";
 
 interface TableOfContentsProps {
-  headings: Heading[];
+  headings: groupedHeading[];
 }
 
 const tocContainer = css`
@@ -119,49 +119,128 @@ const tocItemH3 = css`
   }
 `;
 
+
+const mobileTocContainer = css`
+  display: none;
+  margin-bottom: var(--spacing-md);
+  border: var(--mobile-toc-border);
+  border-radius: var(--mobile-toc-radius);
+  background: var(--mobile-toc-bg);
+  overflow: hidden;
+
+  @media (max-width: 1024px) {
+    display: block;
+  }
+`;
+
+const mobileTocSummary = css`
+  padding: var(--mobile-toc-summary-padding);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  color: var(--color-foreground);
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::before {
+    content: "▶";
+    font-size: var(--text-xs);
+    transition: transform 0.5s linear(0, 0.6 20%, 1.1 55%, 0.97 72%, 1);
+  }
+
+  details[open] &::before {
+    transform: rotate(90deg);
+  }
+`;
+
+const mobileTocContent = css`
+  interpolate-size: allow-keywords;
+  overflow: clip;
+  height: 0;
+  transition: height 0.5s linear(0, 0.6 20%, 1.1 55%, 0.97 72%, 1);
+  padding: 0 var(--mobile-toc-padding);
+
+  details[open] & {
+    height: auto;
+    padding-bottom: var(--mobile-toc-padding);
+  }
+`;
+
+function TocList({
+  grouped,
+  itemH2Class,
+  nestedListClass,
+  itemH3Class,
+  listClass,
+}: {
+  grouped: groupedHeading[];
+  itemH2Class: Promise<string>;
+  nestedListClass: Promise<string>;
+  itemH3Class: Promise<string>;
+  listClass: Promise<string>;
+}) {
+  return (
+    <ul class={listClass}>
+      {grouped.map((group) => (
+        <li key={group.parent.id} class={itemH2Class}>
+          <a href={`#${group.parent.id}`}>{group.parent.text}</a>
+          {group.children.length > 0 && (
+            <ul class={nestedListClass}>
+              {group.children.map((h3) => (
+                <li key={h3.id} class={itemH3Class}>
+                  <a href={`#${h3.id}`}>{h3.text}</a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function MobileTOC({ headings }: TableOfContentsProps) {
+  if (headings.length === 0) {
+    return null;
+  }
+
+  return (
+    <details class={mobileTocContainer}>
+      <summary class={mobileTocSummary}>目次</summary>
+      <div class={mobileTocContent}>
+        <TocList
+          grouped={headings}
+          listClass={tocList}
+          itemH2Class={tocItemH2}
+          nestedListClass={tocNestedList}
+          itemH3Class={tocItemH3}
+        />
+      </div>
+    </details>
+  );
+}
+
 export function TableOfContents({ headings }: TableOfContentsProps) {
   if (headings.length === 0) {
     return null;
   }
 
-  // h3 を親の h2 の下にグループ化
-  const groupedHeadings: { h2: Heading; h3s: Heading[] }[] = [];
-  let currentGroup: { h2: Heading; h3s: Heading[] } | null = null;
-
-  for (const heading of headings) {
-    if (heading.level === 2) {
-      if (currentGroup) {
-        groupedHeadings.push(currentGroup);
-      }
-      currentGroup = { h2: heading, h3s: [] };
-    } else if (heading.level === 3 && currentGroup) {
-      currentGroup.h3s.push(heading);
-    }
-  }
-
-  if (currentGroup) {
-    groupedHeadings.push(currentGroup);
-  }
-
   return (
     <nav class={tocContainer} aria-label="Table of Contents">
       <h2 class={tocTitle}>目次</h2>
-      <ul class={tocList}>
-        {groupedHeadings.map((group) => (
-          <li key={group.h2.id} class={tocItemH2}>
-            <a href={`#${group.h2.id}`}>{group.h2.text}</a>
-            {group.h3s.length > 0 && (
-              <ul class={tocNestedList}>
-                {group.h3s.map((h3) => (
-                  <li key={h3.id} class={tocItemH3}>
-                    <a href={`#${h3.id}`}>{h3.text}</a>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </li>
-        ))}
-      </ul>
+      <TocList
+        grouped={headings}
+        listClass={tocList}
+        itemH2Class={tocItemH2}
+        nestedListClass={tocNestedList}
+        itemH3Class={tocItemH3}
+      />
     </nav>
   );
 }

--- a/app/islands/Header.tsx
+++ b/app/islands/Header.tsx
@@ -212,9 +212,17 @@ const hamburgerMenuClass = css`
   inset: unset;
   position-anchor: --header;
   top: anchor(--header bottom);
-  left: calc(100% - 156px);
+  left: calc(100% - 140px);
   margin-top: calc(-1 * var(--border-width-thick));
   width: 140px;
+
+  @media (max-width: 1100px) {
+    left: calc(100% - 140px - var(--spacing-lg));
+  }
+
+  @media (max-width: 768px) {
+    left: calc(100% - 140px - var(--spacing-sm));
+  }
 
   opacity: 1;
   clip-path: inset(0 0 100% 0);
@@ -271,6 +279,20 @@ const hamburgerMenuClass = css`
 export const Header = ({ initialTheme, currentPath }: { initialTheme: Theme, currentPath: string }) => {
   const [visible, setVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 580px)');
+    const handleBreakpoint = (e: MediaQueryListEvent) => {
+      if (e.matches) {
+        const menu = document.getElementById('menu');
+        if (menu?.matches(':popover-open')) {
+          menu.hidePopover();
+        }
+      }
+    };
+    mq.addEventListener('change', handleBreakpoint);
+    return () => mq.removeEventListener('change', handleBreakpoint);
+  }, []);
 
   useEffect(() => {
     const handleScroll = () => {

--- a/app/islands/Header.tsx
+++ b/app/islands/Header.tsx
@@ -37,7 +37,11 @@ const headerClass = css`
   }
 
   @media (max-width: 1100px) {
-    margin-inline: var(--spacing-md);
+    margin-inline: var(--spacing-lg);
+  }
+
+  @media (max-width: 768px) {
+    margin-inline: var(--spacing-sm);
   }
 `
 const navClass = css`

--- a/app/lib/post.ts
+++ b/app/lib/post.ts
@@ -1,5 +1,7 @@
 import type {
   MDXModule,
+  Heading,
+  groupedHeading,
   PostSummary,
   PostWithContent,
   TagCount,
@@ -13,6 +15,22 @@ import type {
   GetArchives,
   GetAdjacentPosts,
 } from "@/types";
+
+/**
+ * 見出しを階層構造にグループ化する
+ */
+function groupHeadings(headings: Heading[]): groupedHeading[] {
+  return headings.reduce<groupedHeading[]>((groups, heading) => {
+    if (heading.level === 2) {
+      return [...groups, { parent: heading, children: [] }];
+    }
+    if (heading.level === 3 && groups.length > 0) {
+      const last = groups[groups.length - 1];
+      return [...groups.slice(0, -1), { parent: last.parent, children: [...last.children, heading] }];
+    }
+    return groups;
+  }, []);
+}
 
 /**
  * ポストの一覧を取得する
@@ -62,7 +80,7 @@ export const getPostBySlug: GetPostBySlug = async (slug) => {
     ...mod.frontmatter,
     slug,
     Content: mod.default,
-    headings: mod.headings ?? [],
+    headings: groupHeadings(mod.headings ?? []),
   };
 
   return post;

--- a/app/routes/posts/[slug].tsx
+++ b/app/routes/posts/[slug].tsx
@@ -1,7 +1,7 @@
 import { createRoute } from "honox/factory";
 import { getPostBySlug, getAdjacentPosts } from "../../lib/post";
 import { Tag } from "../../components/Tag";
-import { TableOfContents } from "../../components/TableOfContents";
+import { TableOfContents, MobileTOC } from "../../components/TableOfContents";
 import { css } from "hono/css";
 
 const postLayout = css`
@@ -12,7 +12,7 @@ const postLayout = css`
   width: 100%;
 
   @media (max-width: 768px) {
-    padding: 6rem var(--spacing-md-lg) 2rem;
+    padding: 6rem var(--spacing-sm) 2rem;
     max-width: 100vw;
     overflow-x: hidden;
   }
@@ -29,6 +29,7 @@ const contentArea = css`
       gap: 0;
     }
   }
+
 `;
 
 const postArticle = css`
@@ -82,8 +83,7 @@ const postContent = css`
   box-sizing: border-box;
   background-color: var(--color-card-background);
   border: var(--card-border);
-  border-radius: 1rem;
-  box-shadow: var(--card-shadow);
+  border-radius: var(--round-md);
   padding: var(--spacing-xl);
 
   @media (max-width: 768px) {
@@ -91,13 +91,9 @@ const postContent = css`
   }
 
   @media (max-width: 480px) {
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
-    box-shadow: none;
-    padding: var(--spacing-md) var(--spacing-sm);
-    margin-left: calc(-1 * var(--spacing-md-lg));
-    margin-right: calc(-1 * var(--spacing-md-lg));
+    border: var(--card-border);
+    border-radius: var(--round-md);
+    padding: var(--spacing-sm);
     font-size: var(--text-sm);
   }
   
@@ -417,7 +413,7 @@ const postNavigation = css`
 `;
 
 export default createRoute(async (c) => {
-  const slug = c.req.param("slug");
+  const slug = c.req.param("slug") || "";
   const post = await getPostBySlug(slug);
 
   if (!post) {
@@ -462,6 +458,7 @@ export default createRoute(async (c) => {
               ))}
             </div>
           </header>
+          <MobileTOC headings={headings} />
           <section class={postContent}>
             <Content />
           </section>

--- a/app/styles/layers/base.css
+++ b/app/styles/layers/base.css
@@ -336,6 +336,7 @@ body {
   font-family: var(--font-sans);
   background-color: var(--color-background);
   color: var(--color-foreground);
+  word-break: auto-phrase;
   margin: 0;
   padding: 0;
   transition: background-color 0.3s, color 0.3s;

--- a/app/styles/layers/components.css
+++ b/app/styles/layers/components.css
@@ -7,14 +7,14 @@
   --color-header-background: var(--color-neutral-750);
   --color-header-foreground: var(--color-light-500);
   --color-header-border: light-dark(var(--color-neutral-900), var(--color-neutral-600));
-  --color-header-shadow: var(--color-header-border);
+  --color-header-shadow: light-dark(var(--color-neutral-900), var(--color-neutral-950));
   --header-border: var(--border-width-thick) solid var(--color-header-border);
   --header-shadow: 0 2px 0 var(--color-header-shadow);
 
   /* --- Card --- */
   --color-card-background: light-dark(var(--color-neutral-100), var(--color-neutral-750));
   --color-card-border: light-dark(var(--color-neutral-900), var(--color-neutral-600));
-  --color-card-shadow: var(--color-card-border);
+  --color-card-shadow: light-dark(var(--color-neutral-900), var(--color-neutral-950));
   --card-border: var(--border-width-thick) solid var(--color-card-border);
   --card-shadow: 4px 4px 0 var(--color-card-shadow);
   --card-shadow-hover: 2px 2px 0 var(--color-card-shadow);
@@ -25,7 +25,7 @@
   --color-tag-background: var(--color-primary);
   --color-tag-foreground: var(--color-neutral-800);
   --color-tag-border: light-dark(var(--color-neutral-900), var(--color-neutral-600));
-  --color-tag-shadow: var(--color-tag-border);
+  --color-tag-shadow: light-dark(var(--color-neutral-900), var(--color-neutral-950));
   --tag-border: var(--border-width-thick) solid var(--color-tag-border);
   --tag-shadow: 3px 3px 0 var(--color-tag-shadow);
   --tag-shadow-hover: 1.5px 1.5px 0 var(--color-tag-shadow);
@@ -84,6 +84,20 @@
   --toc-selected-item-color: var(--color-neutral-900);
   --toc-target-before-color: light-dark(var(--color-neutral-400), var(--color-neutral-500));
   --toc-target-after-color: light-dark(var(--color-neutral-600), var(--color-neutral-400));
+
+  /* --- Mobile TOC --- */
+  --mobile-toc-padding: var(--size-400);
+  --mobile-toc-summary-padding: var(--size-200) var(--size-400);
+  --mobile-toc-bg: var(--color-card-background);
+  --mobile-toc-border: var(--card-border);
+  --mobile-toc-radius: var(--round-md);
+
+  /* --- TOC FAB --- */
+  --toc-fab-size: var(--size-1000);
+  --toc-fab-bg: var(--color-primary);
+  --toc-fab-color: var(--color-neutral-900);
+  --toc-fab-shadow: var(--shadow-md);
+  --toc-fab-radius: var(--round-full);
 
   /* --- Hero --- */
   --hero-padding-top: var(--size-1200);

--- a/app/styles/layers/tokens.css
+++ b/app/styles/layers/tokens.css
@@ -131,9 +131,9 @@
   --color-background: light-dark(var(--color-neutral-200), var(--color-neutral-800));
   --color-foreground: light-dark(var(--color-neutral-800), var(--color-neutral-200));
   --color-border: light-dark(var(--color-neutral-800), var(--color-neutral-400));
-  --color-shadow: light-dark(var(--color-neutral-700), var(--color-neutral-400));
+  --color-shadow: light-dark(var(--color-neutral-700), var(--color-neutral-950));
   --color-shadow-light: var(--color-neutral-400);
-  --color-shadow-dark: var(--color-neutral-700);
+  --color-shadow-dark: light-dark(var(--color-neutral-700), var(--color-neutral-950));
 
   /* --- Spacing --- */
   --spacing-xs: var(--size-100);

--- a/app/types/post.ts
+++ b/app/types/post.ts
@@ -23,6 +23,11 @@ export interface Heading {
   level: number;
 }
 
+export interface groupedHeading {
+  parent: Heading;
+  children: Heading[];
+}
+
 /** import.meta.globで読み込まれるMDXモジュールの型 */
 export type MDXModule = {
   frontmatter: FrontMatter;
@@ -49,7 +54,7 @@ export interface PostSummary {
 /** 本文コンポーネント付き投稿（詳細ページ用） */
 export interface PostWithContent extends PostSummary {
   Content: MDXComponent;
-  headings: Heading[];
+  headings: groupedHeading[];
 }
 
 /** タグと投稿数 */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       remarkPlugins: [remarkGfm, remarkFrontmatter, remarkMdxFrontmatter],
       rehypePlugins: [
         rehypeSlug,
-        rehypeExtractHeadings,  // rehypeSlug の後に実行（ID 付与後に見出しを抽出）
+        rehypeExtractHeadings,
         [rehypeAutolinkHeadings, {
           behavior: 'wrap',
           properties: {


### PR DESCRIPTION
## Summary

- `headings` の型を `Heading[]` → `groupedHeading[]` に統一し、グループ化ロジックをデータ層（`post.ts`）に集約
- `<details>` + `<summary>` ベースのモバイル用折りたたみ目次を追加（JS 不要、CSS のみ）
- `linear()` イージングで矢印回転・コンテンツ展開アニメーションに spring 感を追加
- 記事詳細ページの `box-shadow` 削除・`padding` 調整でフラットなスタイルに統一
- `body` に `word-break: auto-phrase` を追加し日本語の折り返しを改善
- ヘッダーのレスポンシブマージン調整・ダークモードのシャドウカラー修正

## Test plan

- [ ] デスクトップ（1024px 超）でサイドバー TOC が表示されること
- [ ] モバイル（1024px 以下）でサイドバー TOC が非表示・折りたたみ TOC が表示されること
- [ ] 折りたたみ TOC のタップで展開・矢印が回転すること
- [ ] 記事ページのライト / ダークモード両方でスタイルが崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)