### PR TITLE
feat: 記事のdraft機能を追加

### DIFF
--- a/app/lib/post.ts
+++ b/app/lib/post.ts
@@ -38,7 +38,7 @@ function groupHeadings(headings: Heading[]): groupedHeading[] {
 export const getPosts: GetPosts = async () => {
   const modules = import.meta.glob<MDXModule>("/app/posts/**/*.mdx");
 
-  const posts: PostSummary[] = await Promise.all(
+  const allPosts = await Promise.all(
     Object.entries(modules).map(async ([path, resolver]) => {
       const mod = await resolver();
       const slug = path.match(/([^\/]+)\.mdx$/)?.[1] || "";
@@ -47,6 +47,10 @@ export const getPosts: GetPosts = async () => {
         slug,
       };
     }),
+  );
+
+  const posts: PostSummary[] = allPosts.filter(
+    (post) => !post.draft || import.meta.env.DEV,
   );
 
   return posts.sort(
@@ -73,6 +77,10 @@ export const getPostBySlug: GetPostBySlug = async (slug) => {
   const mod = await resolver();
 
   if (!mod.default) {
+    return null;
+  }
+
+  if (mod.frontmatter.draft && !import.meta.env.DEV) {
     return null;
   }
 

--- a/app/types/post.ts
+++ b/app/types/post.ts
@@ -11,6 +11,8 @@ export interface FrontMatter {
   updatedAt: string;
   tags: string[];
   image: string;
+  /** trueの場合、本番環境では一覧・詳細・タグ・アーカイブに表示されない */
+  draft?: boolean;
 }
 
 /** MDXコンポーネント型 */


### PR DESCRIPTION
## Summary
- `FrontMatter` に `draft?: boolean` を追加
- `getPosts` / `getPostBySlug` で本番環境（`import.meta.env.DEV` が false）の場合に `draft: true` の記事を除外
- `getPostsByTag` / `getArchives` / `getPostsByYearMonth` / `getAdjacentPosts` はすべて `getPosts` 経由のため、一覧・タグ・アーカイブ・前後記事ナビの全てで自動的にdraftが除外される
- 開発環境ではdraft記事もそのままプレビュー可能

## 確認したこと
- 一時的に `draft: true` の記事を作成し `pnpm run build`（本番モード）を実行
  - `dist/*.html`（index/posts/tags/archive）にdraft記事の内容が含まれないことを確認
  - `/posts/:slug` はSSRで `getPostBySlug` がnullを返し404になることを確認

## 既知の制限（要検討）
- クライアントハイドレーション用にMDXがコンパイルされる際、draftフラグに関わらず個別のJSチャンク（`dist/assets/<slug>-*.js`）が静的ファイルとして生成される
- ルーティング・一覧からは除外されるが、ハッシュ付きURLを直接知っていれば内容を取得できてしまう
- 発見可能性は低いが「完全非公開」ではない点は認識した上でこのPRをマージするか判断してほしい

Closes #45

## Test plan
- [x] `pnpm exec tsc --noEmit` で既存エラー以外の新規エラーがないことを確認
- [x] `pnpm run build` が成功する
- [x] draft記事が一覧・詳細・ビルド成果物から除外されることを実機確認