### PR TITLE
feat: sitemap.xml / robots.txtを追加

### DIFF
--- a/app/routes/robots.txt.tsx
+++ b/app/routes/robots.txt.tsx
@@ -1,0 +1,12 @@
+import { createRoute } from "honox/factory";
+import { absoluteUrl } from "@/lib/site";
+
+export default createRoute((c) => {
+  const body = `User-agent: *
+Allow: /
+
+Sitemap: ${absoluteUrl(c, "/sitemap.xml")}
+`;
+
+  return c.body(body, 200, { "Content-Type": "text/plain; charset=UTF-8" });
+});

--- a/app/routes/sitemap.xml.tsx
+++ b/app/routes/sitemap.xml.tsx
@@ -1,0 +1,31 @@
+import { createRoute } from "honox/factory";
+import { getPosts } from "@/lib/post";
+import { absoluteUrl } from "@/lib/site";
+
+const STATIC_PATHS = ["/", "/posts", "/tags", "/about"];
+
+export default createRoute(async (c) => {
+  const posts = await getPosts();
+
+  const urlEntries: { loc: string; lastmod?: string }[] = [
+    ...STATIC_PATHS.map((path) => ({ loc: absoluteUrl(c, path) })),
+    ...posts.map((post) => ({
+      loc: absoluteUrl(c, `/posts/${post.slug}`),
+      lastmod: post.updatedAt,
+    })),
+  ];
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urlEntries
+  .map(
+    (entry) => `  <url>
+    <loc>${entry.loc}</loc>${entry.lastmod ? `\n    <lastmod>${entry.lastmod}</lastmod>` : ""}
+  </url>`,
+  )
+  .join("\n")}
+</urlset>
+`;
+
+  return c.body(body, 200, { "Content-Type": "application/xml; charset=UTF-8" });
+});


### PR DESCRIPTION
## Summary
- `app/routes/sitemap.xml.tsx`: `getPosts()`から記事詳細（`lastmod`は`updatedAt`）と主要固定ページ（`/`・`/posts`・`/tags`・`/about`）を列挙する動的ルート
- `app/routes/robots.txt.tsx`: `Sitemap:`行に#47で導入した`absoluteUrl()`を使い、`VITE_SITE_URL`設定時は本番URL、未設定時はリクエストoriginを反映

## HonoX組み込みのsitemapプラグインを使わなかった理由
`honox/vite`にはsitemap生成のViteプラグインが同梱されている（`node_modules/honox/dist/vite/sitemap.js`）が、中身を読むと`app/routes/`配下のファイルパスをそのまま列挙するだけの実装で、以下の理由でこのプロジェクトには使えないと判断した。

- ブログ記事は`app/posts/`配下のMDXを`import.meta.glob`で動的ロードしており、`app/routes/`にファイルとして存在しないため記事を列挙できない
- draft記事（#45）の除外ロジックがない
- `lastmod`が記事のupdatedAtではなくビルド時刻固定

そのため`getPosts()`を使う自前の動的ルートで実装した。

## ファイル名の付け方について
HonoXのルーティングは`filePathToPath`が末尾の`.tsx`のみを正規表現で除去する実装のため、`sitemap.xml.tsx`のようにドット付き拡張子をそのままファイル名にするだけで`/sitemap.xml`というパスになることを確認した（ブラケットエスケープ等は不要）。

## 確認したこと
- `pnpm exec tsc --noEmit` がエラーなしで通る
- `pnpm run build` で `dist/sitemap.xml` / `dist/robots.txt` が生成される
- `VITE_SITE_URL`ありなしそれぞれでビルドし、URLが正しく切り替わることを確認
- 一時的にdraft記事を追加してビルドし、sitemap.xmlに含まれないことを確認（6 URL → draft追加後も6 URLのまま）

Closes #48

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run build` で sitemap.xml / robots.txt 生成確認
- [x] draft記事の除外確認
- [ ] 実デプロイ後、Google Search Consoleへのsitemap送信で読み込みエラーがないか確認（#54で対応）