### PR TITLE
feat: JSON-LD構造化データ（BlogPosting / WebSite）を追加

### DIFF
--- a/app/lib/site.ts
+++ b/app/lib/site.ts
@@ -2,6 +2,8 @@ import type { Context } from "hono";
 
 export const SITE_NAME = "hiraaaken Blog";
 
+export const AUTHOR_NAME = "hiraaaken";
+
 export const DEFAULT_DESCRIPTION =
   "関西住みエンジニアhiraaakenによる個人技術ブログ。TypeScript・CSS・Honoまわりの学びを書き留めています。";
 
@@ -35,4 +37,74 @@ export function absoluteUrl(c: Context, path: string): string {
 export function resolveOgImage(c: Context, image?: string): string {
   const path = image || DEFAULT_OG_IMAGE_PATH;
   return path.startsWith("http") ? path : absoluteUrl(c, path);
+}
+
+interface JsonLdInput {
+  /** ページ種別。"article"なら記事(BlogPosting)、"/"のwebsiteならサイト(WebSite) */
+  type: "website" | "article";
+  path?: string;
+  title?: string;
+  /** フォールバック適用後の説明文 */
+  description: string;
+  /** 絶対URL（canonical） */
+  canonicalUrl: string;
+  /** 絶対URLのOGP画像 */
+  image: string;
+  /** サイトのオリジン（WebSite用） */
+  siteUrl: string;
+  publishedAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * ページに埋め込むJSON-LD構造化データを組み立てる。
+ * - 記事詳細（type="article"）: BlogPosting
+ * - トップページ（path="/"）: WebSite
+ * - それ以外: null（構造化データを出力しない）
+ */
+export function buildJsonLd(input: JsonLdInput): Record<string, unknown> | null {
+  if (input.type === "article") {
+    return {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: input.title ?? SITE_NAME,
+      description: input.description,
+      datePublished: input.publishedAt,
+      dateModified: input.updatedAt ?? input.publishedAt,
+      author: { "@type": "Person", name: AUTHOR_NAME },
+      publisher: { "@type": "Person", name: AUTHOR_NAME },
+      image: input.image,
+      url: input.canonicalUrl,
+      mainEntityOfPage: { "@type": "WebPage", "@id": input.canonicalUrl },
+    };
+  }
+
+  if ((input.path ?? "/") === "/") {
+    return {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: SITE_NAME,
+      description: input.description,
+      url: input.siteUrl,
+      author: { "@type": "Person", name: AUTHOR_NAME },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * JSON-LDを<script>に安全に埋め込むための文字列化。
+ * "</script>"によるタグ早期終了を防ぐため "<" を、JSで無効な行区切り文字
+ * (U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR)を \uXXXX にエスケープする。
+ * パターンはソースに不可視文字を残さないよう char code から組み立てる。
+ */
+export function serializeJsonLd(obj: Record<string, unknown>): string {
+  const lineSep = String.fromCharCode(0x2028);
+  const paraSep = String.fromCharCode(0x2029);
+  const pattern = new RegExp("[<" + lineSep + paraSep + "]", "g");
+  return JSON.stringify(obj).replace(pattern, (ch) => {
+    const code = ch.charCodeAt(0).toString(16).padStart(4, "0");
+    return "\\u" + code;
+  });
 }

--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -7,7 +7,10 @@ import {
   DEFAULT_DESCRIPTION,
   SITE_NAME,
   absoluteUrl,
+  buildJsonLd,
+  getSiteUrl,
   resolveOgImage,
+  serializeJsonLd,
 } from "@/lib/site";
 
 const mainClass = css`
@@ -38,6 +41,18 @@ export default jsxRenderer(
     const canonicalUrl = absoluteUrl(c, path || currentPath);
     const ogType = type || "website";
     const ogImage = resolveOgImage(c, image);
+
+    const jsonLd = buildJsonLd({
+      type: ogType,
+      path: path || currentPath,
+      title,
+      description: pageDescription,
+      canonicalUrl,
+      image: ogImage,
+      siteUrl: getSiteUrl(c),
+      publishedAt,
+      updatedAt,
+    });
 
     return (
       <html
@@ -71,6 +86,12 @@ export default jsxRenderer(
           <meta name="twitter:title" content={pageTitle} />
           <meta name="twitter:description" content={pageDescription} />
           <meta name="twitter:image" content={ogImage} />
+          {jsonLd && (
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+            />
+          )}
           <script
             dangerouslySetInnerHTML={{
               __html: `


### PR DESCRIPTION
## Summary
#47 のメタ基盤に相乗りし、renderer が既に受け取っているメタ情報（title/description/type/image/publishedAt/updatedAt/path）から JSON-LD を組み立てて `<head>` に出力する。**ルート側は一切変更なし。**

- 記事詳細（`type="article"`）: `BlogPosting`（headline / description / datePublished / dateModified / author / publisher / image / url / mainEntityOfPage）
- トップページ（`path="/"`）: `WebSite`
- それ以外のページ: 出力なし

## 実装
`app/lib/site.ts` に純粋関数を追加:
- `buildJsonLd()`: ページ種別に応じて JSON-LD オブジェクト（or null）を返す
- `serializeJsonLd()`: `<` と行区切り文字（U+2028/U+2029）を `\uXXXX` にエスケープし、`</script>` によるタグ早期終了・スクリプト注入を防止。パターンはソースに不可視文字を残さないよう char code から組み立て

renderer は `buildJsonLd` の結果があれば `<script type="application/ld+json">` を出力するだけ。

## 確認したこと
- [x] `tsc --noEmit` / `vite build` 成功
- [x] トップページに `WebSite` JSON-LD が出力される（`JSON.parse` 通過を確認）
- [x] 記事ページ（SSR）に `BlogPosting` JSON-LD が全必須フィールド付きで出力される
- [x] `/posts` 等の該当しないページには出力されない
- [x] `</script>` を含む文字列が正しくエスケープされ注入を防ぐことを確認

## 補足
`url` / `image` の絶対URLは、SSGページ・`VITE_SITE_URL` 未設定時は `http://localhost` になる（#47と同じ既知の制約）。カスタムドメイン設定（#49）で `VITE_SITE_URL` を設定すれば本番URLになる。デプロイ後は Google のリッチリザルトテストでの確認を推奨。

Closes #51