### PR TITLE
feat: RSSフィード(/feed.xml)を追加

### DIFF
--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -52,6 +52,12 @@ export default jsxRenderer(
           <title>{pageTitle}</title>
           <meta name="description" content={pageDescription} />
           <link rel="canonical" href={canonicalUrl} />
+          <link
+            rel="alternate"
+            type="application/rss+xml"
+            title={`${SITE_NAME} RSS`}
+            href={absoluteUrl(c, "/feed.xml")}
+          />
 
           <meta property="og:site_name" content={SITE_NAME} />
           <meta property="og:title" content={pageTitle} />
@@ -96,6 +102,9 @@ export default jsxRenderer(
           <main class={mainClass}>{children}</main>
 
           <footer class={footerClass}>
+            <p>
+              <a href="/feed.xml">RSS</a>
+            </p>
             <p>&copy; {new Date().getFullYear()} hiraaaken All rights reserved.</p>
           </footer>
         </body>

--- a/app/routes/feed.xml.tsx
+++ b/app/routes/feed.xml.tsx
@@ -1,0 +1,63 @@
+import { createRoute } from "honox/factory";
+import { getPosts } from "@/lib/post";
+import { DEFAULT_DESCRIPTION, SITE_NAME, absoluteUrl, getSiteUrl } from "@/lib/site";
+
+/** フィードに載せる最大件数 */
+const FEED_MAX_ITEMS = 20;
+
+/** XMLの特殊文字をエスケープする（& を最初に処理する） */
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/** 日付文字列(YYYY-MM-DD等)をRFC 822形式に変換する */
+function toRfc822(date: string): string {
+  return new Date(date).toUTCString();
+}
+
+export default createRoute(async (c) => {
+  const posts = (await getPosts()).slice(0, FEED_MAX_ITEMS);
+  const feedUrl = absoluteUrl(c, "/feed.xml");
+  const siteUrl = getSiteUrl(c);
+
+  const items = posts
+    .map((post) => {
+      const url = absoluteUrl(c, `/posts/${post.slug}`);
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <description>${escapeXml(post.description)}</description>
+      <pubDate>${toRfc822(post.publishedAt)}</pubDate>
+    </item>`;
+    })
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(SITE_NAME)}</title>
+    <link>${siteUrl}</link>
+    <description>${escapeXml(DEFAULT_DESCRIPTION)}</description>
+    <language>ja</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`;
+
+  // Content-Type は application/xml にする。
+  // @hono/vite-ssg（hono/ssg）は Content-Type から出力ファイルの拡張子を決めるが、
+  // application/rss+xml は拡張子マップに無く .html が付与され dist/feed.xml.html になってしまう。
+  // application/xml なら dist/feed.xml として正しく事前生成され、静的配信でも拡張子から
+  // 正しい Content-Type が付く。RSSリーダーは application/xml でも問題なく解釈する。
+  return c.body(body, 200, {
+    "Content-Type": "application/xml; charset=UTF-8",
+  });
+});


### PR DESCRIPTION
## Summary
`getPosts()` から最新20件で RSS 2.0 フィードを生成する動的ルート `/feed.xml` を追加。技術ブログ読者はRSS購読率が高く、リピーター獲得に直結する。

- `app/routes/feed.xml.tsx`: フィード本体。記事タイトル・説明文はXMLエスケープ（`&`を最初に処理）、`pubDate`はRFC 822形式に変換。sitemapと同じ `absoluteUrl()` で絶対URLを組み立て
- `app/routes/_renderer.tsx`: `<head>` にRSS自動検出用の `<link rel="alternate" type="application/rss+xml">` を追加、フッターに購読リンクを追加

## Content-Type について（設計判断）
当初 `application/rss+xml` を指定したが、検証で問題が判明した:
- `@hono/vite-ssg`（`hono/ssg`）は Content-Type から出力ファイルの拡張子を決める
- `application/rss+xml` は拡張子マップに無いため `.html` が付与され、`dist/feed.xml.html` として事前生成される
- CF assets のHTMLフォールバックがそれを `/feed.xml` として `text/html` で配信してしまう

sitemap.xml（#48）と同じ `application/xml` に揃えることで `dist/feed.xml` として正しく生成・配信されるようにした。RSSリーダーは `application/xml` でも問題なく解釈する。

## 確認したこと
- [x] `tsc --noEmit` / `vite build` 成功
- [x] `/feed.xml` が `Content-Type: application/xml` で 200 を返し、有効なRSS 2.0（rss要素 + item 2件）
- [x] `VITE_SITE_URL` 設定時、フィード内の全URL（link / atom:link / item link / guid）が本番ドメインになる
- [x] 全ページの `<head>` に alternate link、フッターに購読リンクが出力される
- [x] XMLエスケープが効くこと（`escapeXml` で `& < > " '` を実体参照化）

## 補足
- `VITE_SITE_URL` 未設定時はフィード内URLが `http://localhost` になる（#47/#48と同じ既知の制約）。カスタムドメイン設定（#49）で `VITE_SITE_URL` を設定すれば本番URLになる
- `_renderer.tsx` を変更しているため、同じく renderer を変更する #65（JSON-LD）とマージ時に軽微なコンフリクトが出る可能性あり（head内の別々の行なので解消は容易）

Closes #50