### PR TITLE
feat: カスタムドメイン(hiraaaken.dev)を設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,11 @@ jobs:
 
       - run: aube install --frozen-lockfile
 
+      # canonical / OGP / sitemap / feed / JSON-LD の絶対URLを本番ドメインで埋め込む。
+      # SSGで事前生成されるページはビルド時のこの値が使われる（未設定だとlocalhostになる）。
       - run: aube run build
+        env:
+          VITE_SITE_URL: https://hiraaaken.dev
 
       - uses: cloudflare/wrangler-action@v3
         with:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,7 +8,13 @@
   ],
   "assets": {
     "directory": "./dist"
-  }
+  },
+  "routes": [
+    {
+      "pattern": "hiraaaken.dev",
+      "custom_domain": true
+    }
+  ]
   // "vars": {
   //   "MY_VAR": "my-variable"
   // },


### PR DESCRIPTION
## Summary
Worker を apex ドメイン `hiraaaken.dev` で配信し、SEO関連の絶対URLを本番ドメインで埋め込む。

- `wrangler.jsonc`: `routes` に `custom_domain: true` で `hiraaaken.dev` を追加。ゾーンはCloudflareに登録済みのため、デプロイ時にDNSレコードと証明書が**自動でプロビジョニングされる**（手動のDNS/証明書設定は不要）
- `.github/workflows/deploy.yml`: ビルドステップに `VITE_SITE_URL=https://hiraaaken.dev` を追加。canonical / OGP / sitemap / feed / JSON-LD の絶対URLが本番ドメインになる（#47で用意した仕組み。未設定時は localhost フォールバックだった）。公開URLのためシークレットではなくワークフローに直書き

## 確認したこと
- [x] `wrangler deploy --dry-run` が成功（`custom_domain` ルートを含む設定が有効にコンパイルされる）
- [x] `VITE_SITE_URL=https://hiraaaken.dev` でビルドし、sitemap / feed / canonical / robots / JSON-LD の全URLが `https://hiraaaken.dev` になることを確認

## ⚠️ マージ・デプロイ時の手動確認（Cloudflare側 / 要オーナー操作）
1. **既存DNSレコードの確認**: `hiraaaken.dev`（apex）に既存の A / CNAME レコードがあると Custom Domain の作成に失敗する（Cloudflareの制約）。ランディングページ等でapexを使っている場合は事前に該当レコードを削除してください
2. **デプロイ**: このPRをマージ → CI（`main` push）で `wrangler deploy` が走り、Custom Domain・DNS・証明書が自動作成される
3. **証明書発行待ち**: 反映まで数分かかる場合あり。`https://hiraaaken.dev` でブログが表示されることを確認
4. **workers.dev の扱い（任意）**: workers.dev サブドメインも引き続きアクセス可能。重複コンテンツは canonical が `hiraaaken.dev` を指すため実害は小さいが、気になる場合は `"workers_dev": false` を wrangler.jsonc に追加して無効化できる（別PRでも可）

## 補足
これがマージ・デプロイされると、#47/#48/#50/#51 で入れた canonical・OGP・sitemap・RSS・JSON-LD の全URLが本番ドメインで正しく機能するようになります（Search Console 登録 #54 の前提）。

Closes #49