### PR TITLE
fix: Aboutページの技術スタック更新とフッターRSSリンクをアイコン化

### DIFF
--- a/app/components/ui/RssIcon.tsx
+++ b/app/components/ui/RssIcon.tsx
@@ -1,0 +1,7 @@
+export default function RssIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6.18 15.64a2.18 2.18 0 1 1 0 4.36 2.18 2.18 0 0 1 0-4.36zM4 4.44v3.18c7.29 0 13.2 5.9 13.2 13.2h3.18C20.38 12.14 12.68 4.44 4 4.44zM4 10.9v3.18a7.35 7.35 0 0 1 7.35 7.35h3.18A10.53 10.53 0 0 0 4 10.9z" />
+    </svg>
+  )
+}

--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -2,6 +2,7 @@ import { jsxRenderer } from "hono/jsx-renderer";
 import { getCookie } from "hono/cookie";
 import { Link, Script } from "honox/server";
 import { Header } from "../components/Header";
+import RssIcon from "@/components/ui/RssIcon";
 import { css, Style } from "hono/css";
 import {
   DEFAULT_DESCRIPTION,
@@ -26,6 +27,26 @@ const footerClass = css`
   margin-top: auto;
   font-size: var(--text-body-sm);
   color: var(--color-muted);
+`;
+
+const footerLinksClass = css`
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-sm);
+`;
+
+const footerLinkClass = css`
+  display: inline-flex;
+  color: inherit;
+  opacity: 0.6;
+  transition: opacity var(--duration-base) var(--ease-standard);
+
+  @media (hover: hover) {
+    &:hover {
+      opacity: 1;
+    }
+  }
 `;
 
 export default jsxRenderer(
@@ -123,9 +144,15 @@ export default jsxRenderer(
           <main class={mainClass}>{children}</main>
 
           <footer class={footerClass}>
-            <p>
-              <a href="/feed.xml">RSS</a>
-            </p>
+            <div class={footerLinksClass}>
+              <a
+                href="/feed.xml"
+                class={footerLinkClass}
+                aria-label="RSSフィード"
+              >
+                <RssIcon size={18} />
+              </a>
+            </div>
             <p>&copy; {new Date().getFullYear()} hiraaaken All rights reserved.</p>
           </footer>
         </body>

--- a/app/routes/about/index.tsx
+++ b/app/routes/about/index.tsx
@@ -195,10 +195,14 @@ const techStacks: TechStack[] = [
         name: "Haskell",
         rate: 1,
       },
+      {
+        name: "CSS",
+        rate: 2,
+      },
     ],
   },
   {
-    category: "Framworks/Libraries",
+    category: "Frameworks/Libraries",
     stacks: [
       {
         name: "Vue.js",
@@ -210,7 +214,7 @@ const techStacks: TechStack[] = [
       },
       {
         name: "Hono/HonoX",
-        rate: 1,
+        rate: 2,
       },
       {
         name: "Svelte",
@@ -291,7 +295,7 @@ export default createRoute((c) => {
             アウトプットする場として、気軽に更新していく予定です👀
           </p>
           <p>
-            フロント、バックエンド問わず色々興味がありますが、最近は特に 型 と Web標準（CSS/HTML仕様）に興味があります。<br />
+            フロント、バックエンド問わず色々興味がありますが、最近は特に型とWeb標準（CSS/HTML仕様）に興味があります。
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
issue #68「各エリアのデスクリプションを調整」への対応。本文がなかったため、Aboutページの内容を精査したところ、実態と乖離した記述・体裁の乱れが見つかった。

### About（技術スタック・自己紹介文）
- **タイポ修正**: `Framworks/Libraries` → `Frameworks/Libraries`
- **Hono/HonoX を ★☆☆ → ★★☆**: このブログ自体がHonoX + CSS Anchor Positioning + コンテナクエリ + Popover APIなど踏み込んだ実装で作られており、評価が古いまま止まっていた（ユーザー確認済み）
- **Languages に CSS（★★☆）を追加**: 自己紹介文で「Web標準（CSS/HTML仕様）に興味がある」と書いている一方、スタック一覧に現れていなかったギャップを解消（ユーザー確認済み）
- 自己紹介3段落目の、文末に浮いていた空の`<br />`と単語間の余分な空白を除去

### フッターのRSSリンク
テキストリンク「RSS」が`footerClass`の`text-align: center`で独立した見出しのように浮いて見えていた（ユーザー指摘）。Aboutカードのsnsリンク（GitHub/X/Zennアイコン）と同じ `inline-flex` アイコンパターンに統一。
- `app/components/ui/RssIcon.tsx` を新規作成。既存アイコン（GithubIcon/XIcon/ZennIcon）と同じ作法（`fill="currentColor"` / `viewBox="0 0 24 24"`、Material Design rss_feed グリフ）
- `_renderer.tsx` にアイコンリンク用のスタイル（`footerLinksClass`/`footerLinkClass`）を追加し、テキストリンクを置き換え

## 確認したこと
- [x] `tsc --noEmit` / `vite build` 成功
- [x] ビルド後のHTMLでタイポ解消・Hono/HonoX rate:2・CSS追加を確認
- [x] フッターのRSSリンクがSVGアイコンとして正しく出力され、Aboutのsnsリンクと同じCSSパターン（inline-flex + ホバーでopacity変化）になっていることを確認

Closes #68